### PR TITLE
Added multi-format date parsing support to DateTools

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Select Xcode  
-      run: sudo xcode-select -switch /Applications/Xcode_16.app && /usr/bin/xcodebuild -version
+      run: sudo xcode-select -switch /Applications/Xcode_16.4.app && /usr/bin/xcodebuild -version
       # https://github.com/actions/runner-images/blob/main/images/macos/macos-15-arm64-Readme.md
     - name: Boot iOS Simulator
       run: >

--- a/SearchOps.xcodeproj/project.pbxproj
+++ b/SearchOps.xcodeproj/project.pbxproj
@@ -2858,7 +2858,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 13.5;
-				MARKETING_VERSION = 3.0;
+				MARKETING_VERSION = 3.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.mccaffers.searchops.prod;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -2907,7 +2907,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 13.5;
-				MARKETING_VERSION = 3.0;
+				MARKETING_VERSION = 3.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.mccaffers.searchops.prod;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Source/Core/Utilities/DateTools.swift
+++ b/Source/Core/Utilities/DateTools.swift
@@ -57,30 +57,71 @@ public class DateTools {
     
   }
   
-  public static func buildDateLarge(input:String) -> String {
-    if let dateObj = getDate(input: input) {
-      
+  public static func buildDateLarge(input: String) -> String {
+      if let dateObj = getDate(input: input) {
+          let dateFormatterPrint = DateFormatter()
+          dateFormatterPrint.dateFormat = "MMM d, yyyy HH:mm:ss"
+          return dateFormatterPrint.string(from: dateObj)
+      }
+      return ""
+  }
+
+  public static func buildDateLarge(input: Date) -> String {
       let dateFormatterPrint = DateFormatter()
-      dateFormatterPrint.dateFormat = "MMM d, yyyy HH:mm:ss"
+      dateFormatterPrint.dateFormat = "d MMM yyyy HH:mm:ss.SSSS"
+      return dateFormatterPrint.string(from: input)
+  }
+
+  public static func getDate(input: String) -> Date? {
+      // Array of possible date formats to try
+      let dateFormats = [
+          "yyyy-MM-dd'T'HH:mm:ss.SSSZ",     // Original format with timezone
+          "yyyy-MM-dd'T'HH:mm:ss.SSS",      // ISO with milliseconds
+          "yyyy-MM-dd'T'HH:mm:ss",          // ISO basic format (your example)
+          "yyyy-MM-dd HH:mm:ss.SSSZ",       // Space separated with timezone
+          "yyyy-MM-dd HH:mm:ss.SSS",        // Space separated with milliseconds
+          "yyyy-MM-dd HH:mm:ss",            // Space separated basic
+          "yyyy-MM-dd'T'HH:mm:ssZ",         // ISO with timezone, no milliseconds
+          "yyyy-MM-dd'T'HH:mm:ss.SSSSSS",   // ISO with microseconds
+          "MMM d, yyyy HH:mm:ss",           // Human readable format
+          "d MMM yyyy HH:mm:ss.SSSS",       // Alternative human readable
+          "yyyy-MM-dd",                     // Date only
+      ]
       
-      return dateFormatterPrint.string(from: dateObj)
-    }
-    
-    return ""
-  }
-  
-  public static func buildDateLarge(input:Date) -> String {
-    let dateFormatterPrint = DateFormatter()
-    dateFormatterPrint.dateFormat = "d MMM yyyy HH:mm:ss.SSSS"
-    return dateFormatterPrint.string(from: input)
-  }
-    
-  public static func getDate(input:String) -> Date? {
-    let dateFormatter = DateFormatter()
-    dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
-    dateFormatter.timeZone = TimeZone.current
-    dateFormatter.locale = Locale.current
-    return dateFormatter.date(from: input) // replace Date String
+      // Try each format until one works
+      for format in dateFormats {
+          let dateFormatter = DateFormatter()
+          dateFormatter.dateFormat = format
+          dateFormatter.timeZone = TimeZone.current
+          dateFormatter.locale = Locale.current
+          
+          if let date = dateFormatter.date(from: input) {
+              return date
+          }
+      }
+      
+      // Try ISO8601DateFormatter as fallback
+      let iso8601Formatter = ISO8601DateFormatter()
+      
+      // Try with full internet date time format
+      iso8601Formatter.formatOptions = [.withInternetDateTime]
+      if let date = iso8601Formatter.date(from: input) {
+          return date
+      }
+      
+      // Try with date, time, and fractional seconds (no timezone)
+      iso8601Formatter.formatOptions = [.withFullDate, .withFullTime, .withDashSeparatorInDate, .withColonSeparatorInTime]
+      if let date = iso8601Formatter.date(from: input) {
+          return date
+      }
+      
+      // Try basic format with just date and time
+      iso8601Formatter.formatOptions = [.withFullDate, .withFullTime, .withDashSeparatorInDate, .withColonSeparatorInTime, .withFractionalSeconds]
+      if let date = iso8601Formatter.date(from: input) {
+          return date
+      }
+      
+      return nil
   }
   
   public static func dateString(_ dateInput: Date) -> String {

--- a/Source/Platforms/iOS/Settings/ReleaseNotes/ReleaseNotesList.swift
+++ b/Source/Platforms/iOS/Settings/ReleaseNotes/ReleaseNotesList.swift
@@ -26,7 +26,7 @@ struct ReleaseNotesList: View {
         ReleaseNotesListButton(releaseDate: Calendar.current.date(from: DateComponents(year: 2025, month: 9, day: 5))!,
                                buttonText: "Version 3.1",
                                buttonDescription: "Fixing an issue with the date rendering",
-                               buttonAction: { showingRelease = "Version 3.0" },  activeButton: false, isLatest: true)
+                               buttonAction: { },  activeButton: false, isLatest: true)
         .padding(.top, 15)
         
         ReleaseNotesListButton(releaseDate: Calendar.current.date(from: DateComponents(year: 2025, month: 6, day: 10))!,

--- a/Source/Platforms/iOS/Settings/ReleaseNotes/ReleaseNotesList.swift
+++ b/Source/Platforms/iOS/Settings/ReleaseNotes/ReleaseNotesList.swift
@@ -23,10 +23,16 @@ struct ReleaseNotesList: View {
     ScrollView{
       VStack(spacing:25) {
         
+        ReleaseNotesListButton(releaseDate: Calendar.current.date(from: DateComponents(year: 2025, month: 9, day: 5))!,
+                               buttonText: "Version 3.1",
+                               buttonDescription: "Fixing an issue with the date rendering",
+                               buttonAction: { showingRelease = "Version 3.0" },  activeButton: false, isLatest: true)
+        .padding(.top, 15)
+        
         ReleaseNotesListButton(releaseDate: Calendar.current.date(from: DateComponents(year: 2025, month: 6, day: 10))!,
                                buttonText: "Version 3",
                                buttonDescription: "Search Ops is now completely Open Source, entire application on Github, with a Convenience Pricing Model, a small one time fee for lifetime automated updates",
-                               buttonAction: { showingRelease = "Version 3.0" },  activeButton: true, isLatest: true)
+                               buttonAction: { showingRelease = "Version 3.0" },  activeButton: true, isLatest: false)
         .padding(.top, 15)
 
         ReleaseNotesListButton(releaseDate: Calendar.current.date(from: DateComponents(year: 2024, month: 9, day: 3))!,

--- a/Tests/UtilityTests/DateToolsTests.swift
+++ b/Tests/UtilityTests/DateToolsTests.swift
@@ -144,4 +144,116 @@ class DateToolsTests: XCTestCase {
     XCTAssertEqual(realmObj.period, filter.period, "Realm object period should match the filter's period.")
     XCTAssertEqual(realmObj.value, filter.value, "Realm object value should match the filter's value.")
   }
+
+     
+     // MARK: - ISO 8601 Format Tests
+     func testBuildDateLargeWithISO8601BasicFormat() {
+         let testDate = "2025-09-03T07:37:01"
+         XCTAssertEqual(DateTools.buildDateLarge(input: testDate), "Sep 3, 2025 07:37:01")
+     }
+     
+     func testBuildDateLargeWithISO8601WithMilliseconds() {
+         let testDate = "2023-12-25T15:30:45.123"
+         XCTAssertEqual(DateTools.buildDateLarge(input: testDate), "Dec 25, 2023 15:30:45")
+     }
+          
+     func testBuildDateLargeWithISO8601WithMicroseconds() {
+         let testDate = "2024-03-10T14:22:33.456789"
+         XCTAssertEqual(DateTools.buildDateLarge(input: testDate), "Mar 10, 2024 14:22:33")
+     }
+     
+     // MARK: - Space-Separated Format Tests
+     func testBuildDateLargeWithSpaceSeparatedFormat() {
+         let testDate = "2024-08-20 11:15:30"
+         XCTAssertEqual(DateTools.buildDateLarge(input: testDate), "Aug 20, 2024 11:15:30")
+     }
+     
+     func testBuildDateLargeWithSpaceSeparatedWithMilliseconds() {
+         let testDate = "2024-11-01 16:45:22.789"
+         XCTAssertEqual(DateTools.buildDateLarge(input: testDate), "Nov 1, 2024 16:45:22")
+     }
+         
+     // MARK: - Date-Only Format Tests
+     func testBuildDateLargeWithDateOnly() {
+         let testDate = "2024-07-04"
+         XCTAssertEqual(DateTools.buildDateLarge(input: testDate), "Jul 4, 2024 00:00:00")
+     }
+     
+     // MARK: - Human-Readable Format Tests
+     func testBuildDateLargeWithHumanReadableFormat() {
+         let testDate = "Mar 15, 2024 13:45:30"
+         XCTAssertEqual(DateTools.buildDateLarge(input: testDate), "Mar 15, 2024 13:45:30")
+     }
+     
+     // MARK: - Edge Cases and Invalid Formats
+     func testBuildDateLargeWithInvalidDateReturnsEmptyString() {
+         let testDate = "invalid-date-format"
+         XCTAssertEqual(DateTools.buildDateLarge(input: testDate), "")
+     }
+     
+     func testBuildDateLargeWithEmptyStringReturnsEmptyString() {
+         let testDate = ""
+         XCTAssertEqual(DateTools.buildDateLarge(input: testDate), "")
+     }
+     
+     func testBuildDateLargeWithPartialDateReturnsEmptyString() {
+         let testDate = "2024-13-45"  // Invalid month
+         XCTAssertEqual(DateTools.buildDateLarge(input: testDate), "")
+     }
+     
+     // MARK: - Date Object Input Tests
+     func testBuildDateLargeWithDateObject() {
+         let calendar = Calendar.current
+         let dateComponents = DateComponents(year: 2024, month: 5, day: 20, hour: 10, minute: 30, second: 45, nanosecond: 123456789)
+         let testDate = calendar.date(from: dateComponents)!
+         let result = DateTools.buildDateLarge(input: testDate)
+         XCTAssertTrue(result.contains("20 May 2024 10:30:45"))
+     }
+     
+     // MARK: - Boundary Tests
+     func testBuildDateLargeWithLeapYearDate() {
+         let testDate = "2024-02-29T12:00:00"
+         XCTAssertEqual(DateTools.buildDateLarge(input: testDate), "Feb 29, 2024 12:00:00")
+     }
+     
+     func testBuildDateLargeWithNewYearDate() {
+         let testDate = "2024-01-01T00:00:01"
+         XCTAssertEqual(DateTools.buildDateLarge(input: testDate), "Jan 1, 2024 00:00:01")
+     }
+     
+     func testBuildDateLargeWithEndOfYearDate() {
+         let testDate = "2024-12-31T23:59:59"
+         XCTAssertEqual(DateTools.buildDateLarge(input: testDate), "Dec 31, 2024 23:59:59")
+     }
+     
+     // MARK: - getDate Function Direct Tests
+     func testGetDateWithVariousFormats() {
+         let testCases = [
+             "2025-09-03T07:37:01",
+             "2024-12-25T15:30:45.123",
+             "2024-06-15 09:45:30",
+             "2024-07-04",
+             "2023-11-11T11:11:11.111Z"
+         ]
+         
+         for testCase in testCases {
+             let result = DateTools.getDate(input: testCase)
+             XCTAssertNotNil(result, "Failed to parse date: \(testCase)")
+         }
+     }
+     
+     func testGetDateWithInvalidFormatsReturnsNil() {
+         let invalidCases = [
+             "not-a-date",
+             "2024-13-01",  // Invalid month
+             "2024-02-30",  // Invalid day for February
+             "25:00:00",    // Invalid hour
+             ""
+         ]
+         
+         for testCase in invalidCases {
+             let result = DateTools.getDate(input: testCase)
+             XCTAssertNil(result, "Should return nil for invalid date: \(testCase)")
+         }
+     }
 }


### PR DESCRIPTION
- Enhanced getDate() to handle multiple date string formats including:
  - ISO 8601 with/without timezone and milliseconds
  - Space-separated date/time formats
  - Human-readable formats (MMM d, yyyy)
  - Date-only formats
- Added fallback ISO8601DateFormatter with various option combinations
- Maintains backward compatibility with existing format support
- Fixes parsing issues with strings like "2025-09-03T07:37:01"
- Improves robustness by trying formats in order of specificity

This resolves date parsing failures when input strings don't match the single expected format, making the date utilities more flexible for handling various API responses and user inputs.