### PR TITLE
Updated to allow switching between HTTPS and HTTP URI schemes in macOS version

### DIFF
--- a/SearchOps.xcodeproj/project.pbxproj
+++ b/SearchOps.xcodeproj/project.pbxproj
@@ -224,6 +224,7 @@
 		945FAB142C32929A0091003F /* macosDatePickerRefreshView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 945FAB132C32929A0091003F /* macosDatePickerRefreshView.swift */; };
 		945FAB162C32932B0091003F /* macosDatePickerRelativeCustomView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 945FAB152C32932B0091003F /* macosDatePickerRelativeCustomView.swift */; };
 		946563E92C578902004D153D /* macosSearchHomeRelativeCustomView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 946563E82C578902004D153D /* macosSearchHomeRelativeCustomView.swift */; };
+		946625CA2E774F9900B39CF8 /* macosHostsSchemePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 946625C92E774F9900B39CF8 /* macosHostsSchemePickerView.swift */; };
 		9467F3A32A71195300A0F80C /* SettingsAnalyticsMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9467F3A22A71195300A0F80C /* SettingsAnalyticsMessageView.swift */; };
 		946C94592C388114003C3EAB /* macosSearchHistoryButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 946C94582C388114003C3EAB /* macosSearchHistoryButton.swift */; };
 		946C945B2C3881FA003C3EAB /* macosSearchHistoryButtonLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 946C945A2C3881FA003C3EAB /* macosSearchHistoryButtonLabel.swift */; };
@@ -645,6 +646,7 @@
 		94623E342DC8E2BD0092EE04 /* PRIVACY.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = PRIVACY.md; sourceTree = "<group>"; };
 		94623E352DC8E2BD0092EE04 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		946563E82C578902004D153D /* macosSearchHomeRelativeCustomView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = macosSearchHomeRelativeCustomView.swift; sourceTree = "<group>"; };
+		946625C92E774F9900B39CF8 /* macosHostsSchemePickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = macosHostsSchemePickerView.swift; sourceTree = "<group>"; };
 		9467F3A22A71195300A0F80C /* SettingsAnalyticsMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsAnalyticsMessageView.swift; sourceTree = "<group>"; };
 		946C94582C388114003C3EAB /* macosSearchHistoryButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = macosSearchHistoryButton.swift; sourceTree = "<group>"; };
 		946C945A2C3881FA003C3EAB /* macosSearchHistoryButtonLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = macosSearchHistoryButtonLabel.swift; sourceTree = "<group>"; };
@@ -2082,6 +2084,7 @@
 				94A15C6A2C5B5CB90087F95A /* macosHostAddConnectionDetailsView.swift */,
 				94A15C6C2C5B5D020087F95A /* macosHostAddAuthenticationViews.swift */,
 				94BAAE742C6355A500C9E274 /* macosHostsTestConnectionView.swift */,
+				946625C92E774F9900B39CF8 /* macosHostsSchemePickerView.swift */,
 			);
 			path = macosHostsAdd;
 			sourceTree = "<group>";
@@ -2489,6 +2492,7 @@
 				944AD6872A66C259000E16E1 /* SearchQueryDatePopupRelative.swift in Sources */,
 				941325EA2BC8349F00AC438F /* KeyboardUtils.swift in Sources */,
 				940322482A4D8B4B00FC8BBE /* SearchResultsActionsView.swift in Sources */,
+				946625CA2E774F9900B39CF8 /* macosHostsSchemePickerView.swift in Sources */,
 				9403225B2A4D8B4B00FC8BBE /* SearchRangeSheetHeader.swift in Sources */,
 				940322852A4D8B4C00FC8BBE /* AddElasticKeyboardToolbarView.swift in Sources */,
 				9403226F2A4D8B4C00FC8BBE /* DateRangeSheetHeader.swift in Sources */,
@@ -2833,7 +2837,7 @@
 				CODE_SIGN_ENTITLEMENTS = Source/SearchOpsApp.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 3;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"Source/Static/Preview.xcassets\"";
 				DEVELOPMENT_TEAM = "";
@@ -2858,7 +2862,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 13.5;
-				MARKETING_VERSION = 3.1;
+				MARKETING_VERSION = 3.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.mccaffers.searchops.prod;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -2882,7 +2886,7 @@
 				CODE_SIGN_ENTITLEMENTS = Source/SearchOpsApp.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 3;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"Source/Static/Preview.xcassets\"";
 				DEVELOPMENT_TEAM = "";
@@ -2907,7 +2911,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 13.5;
-				MARKETING_VERSION = 3.1;
+				MARKETING_VERSION = 3.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.mccaffers.searchops.prod;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/SearchOps.xcodeproj/project.pbxproj
+++ b/SearchOps.xcodeproj/project.pbxproj
@@ -2837,7 +2837,7 @@
 				CODE_SIGN_ENTITLEMENTS = Source/SearchOpsApp.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 4;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"Source/Static/Preview.xcassets\"";
 				DEVELOPMENT_TEAM = "";
@@ -2886,7 +2886,7 @@
 				CODE_SIGN_ENTITLEMENTS = Source/SearchOpsApp.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 4;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"Source/Static/Preview.xcassets\"";
 				DEVELOPMENT_TEAM = "";

--- a/Source/Core/Constants.swift
+++ b/Source/Core/Constants.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 public class Constants {
-  private(set) public static var defaultPort = "443"
+  private(set) public static var defaultPort = "9200"
   private(set) public static var defaultRequestTimeout = 15.0
 }
 

--- a/Source/Core/Constants.swift
+++ b/Source/Core/Constants.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 public class Constants {
-  private(set) public static var defaultPort = "9200"
+  private(set) public static var defaultPort = "443"
   private(set) public static var defaultRequestTimeout = 15.0
 }
 

--- a/Source/Platforms/macOS/Hosts/macosHostsAdd/macosHostAddConnectionDetailsView.swift
+++ b/Source/Platforms/macOS/Hosts/macosHostsAdd/macosHostAddConnectionDetailsView.swift
@@ -148,7 +148,9 @@ struct macosHostAddConnectionDetailsView: View {
                 // Sets the scheme on host
                 host.host?.scheme = newValue
                 // Updates the local schemeUpdate state for state management
+              if self.schemeUpdate != newValue {
                 self.schemeUpdate = newValue
+              }
 
                 // Shows or hides the self-signed certificate option based on scheme
                 if newValue == HostScheme.HTTPS {

--- a/Source/Platforms/macOS/Hosts/macosHostsAdd/macosHostAddConnectionDetailsView.swift
+++ b/Source/Platforms/macOS/Hosts/macosHostsAdd/macosHostAddConnectionDetailsView.swift
@@ -217,7 +217,7 @@ struct macosHostAddConnectionDetailsView: View {
                   .stroke(selectedHostnameField ? Color("LabelBackgroundBorder") : Color("BackgroundAlt"), lineWidth: 1)
               )
             
-            TextField("Port (defaults 9200)", text: $port)
+            TextField("Port (defaults 443)", text: $port)
               .textFieldStyle(PlainTextFieldStyle())
               .padding(EdgeInsets(top: 0, leading: 6, bottom: 0, trailing: 6))
               .frame(height: 36)

--- a/Source/Platforms/macOS/Hosts/macosHostsAdd/macosHostAddConnectionDetailsView.swift
+++ b/Source/Platforms/macOS/Hosts/macosHostsAdd/macosHostAddConnectionDetailsView.swift
@@ -23,7 +23,7 @@ struct macosHostAddConnectionDetailsView: View {
   @State var selectedHostnameField = false
   @State var selectedPortField = false
   @State var selectedCloudIDField = false
-  @State var schemaUpdate : HostScheme = HostScheme.HTTPS
+  @State var schemeUpdate : HostScheme = HostScheme.HTTPS
   @Binding var isHostValid : Bool
   
   @State var showSelfSignedView : Bool = false
@@ -137,41 +137,39 @@ struct macosHostAddConnectionDetailsView: View {
         } else if connectionType == .URL {
           VStack (spacing:5) {
             
-            macosHostsSchemePickerView(localScheme: $schemaUpdate)
-              .onChange(of: schemaUpdate)  { newValue in
+            // updateScheme updates the scheme for the host and manages related UI state.
+            let updateScheme: (HostScheme) -> Void = { newValue in
+                
+                // Ensure host is initialized
                 if host.host == nil {
                   host.host = HostURL()
                 }
-                host.host?.scheme = newValue
                 
-                if self.schemaUpdate == HostScheme.HTTPS {
+                // Sets the scheme on host
+                host.host?.scheme = newValue
+                // Updates the local schemeUpdate state for state management
+                self.schemeUpdate = newValue
+
+                // Shows or hides the self-signed certificate option based on scheme
+                if newValue == HostScheme.HTTPS {
                   showSelfSignedView = true
                 } else {
                   showSelfSignedView = false
                   host.host?.selfSignedCertificate = false
                 }
+            }
+            
+            macosHostsSchemePickerView(localScheme: $schemeUpdate)
+              .onChange(of: schemeUpdate)  { newValue in
+                updateScheme(newValue)
               }
               .onAppear {
-                
                 if let item = item,
                    let currentHost = item.host {
-                  if host.host == nil {
-                    host.host = HostURL()
-                  }
-                  host.host?.scheme = currentHost.scheme
-                  self.schemaUpdate = currentHost.scheme
-                  
+                  updateScheme(currentHost.scheme)
                 } else if let scheme = host.host?.scheme {
-                  self.schemaUpdate = scheme
+                  updateScheme(scheme)
                 }
-                
-                if self.schemaUpdate == HostScheme.HTTPS {
-                  showSelfSignedView = true
-                } else {
-                  showSelfSignedView = false
-                  host.host?.selfSignedCertificate = false
-                }
-                
               }
           }
           VStack (spacing:5) {
@@ -179,10 +177,9 @@ struct macosHostAddConnectionDetailsView: View {
               .font(.system(size:12))
               .foregroundStyle(Color("TextSecondary"))
               .frame(maxWidth: .infinity, alignment: .leading)
-            
            
             
-            TextField("URL", text: $hostURL)
+            TextField("URL (eg. myhost.example.com)", text: $hostURL)
               .textFieldStyle(PlainTextFieldStyle())
               .padding(EdgeInsets(top: 0, leading: 6, bottom: 0, trailing: 6))
               .frame(height: 36)
@@ -220,7 +217,7 @@ struct macosHostAddConnectionDetailsView: View {
                   .stroke(selectedHostnameField ? Color("LabelBackgroundBorder") : Color("BackgroundAlt"), lineWidth: 1)
               )
             
-            TextField("Port (defaults 443)", text: $port)
+            TextField("Port (defaults 9200)", text: $port)
               .textFieldStyle(PlainTextFieldStyle())
               .padding(EdgeInsets(top: 0, leading: 6, bottom: 0, trailing: 6))
               .frame(height: 36)

--- a/Source/Platforms/macOS/Hosts/macosHostsAdd/macosHostAddConnectionDetailsView.swift
+++ b/Source/Platforms/macOS/Hosts/macosHostsAdd/macosHostAddConnectionDetailsView.swift
@@ -23,8 +23,10 @@ struct macosHostAddConnectionDetailsView: View {
   @State var selectedHostnameField = false
   @State var selectedPortField = false
   @State var selectedCloudIDField = false
-  
+  @State var schemaUpdate : HostScheme = HostScheme.HTTPS
   @Binding var isHostValid : Bool
+  
+  @State var showSelfSignedView : Bool = false
   
     var body: some View {
       VStack(spacing:10) {
@@ -134,10 +136,51 @@ struct macosHostAddConnectionDetailsView: View {
           }
         } else if connectionType == .URL {
           VStack (spacing:5) {
-            Text("Host URL and Port")
+            
+            macosHostsSchemePickerView(localScheme: $schemaUpdate)
+              .onChange(of: schemaUpdate)  { newValue in
+                if host.host == nil {
+                  host.host = HostURL()
+                }
+                host.host?.scheme = newValue
+                
+                if self.schemaUpdate == HostScheme.HTTPS {
+                  showSelfSignedView = true
+                } else {
+                  showSelfSignedView = false
+                  host.host?.selfSignedCertificate = false
+                }
+              }
+              .onAppear {
+                
+                if let item = item,
+                   let currentHost = item.host {
+                  if host.host == nil {
+                    host.host = HostURL()
+                  }
+                  host.host?.scheme = currentHost.scheme
+                  self.schemaUpdate = currentHost.scheme
+                  
+                } else if let scheme = host.host?.scheme {
+                  self.schemaUpdate = scheme
+                }
+                
+                if self.schemaUpdate == HostScheme.HTTPS {
+                  showSelfSignedView = true
+                } else {
+                  showSelfSignedView = false
+                  host.host?.selfSignedCertificate = false
+                }
+                
+              }
+          }
+          VStack (spacing:5) {
+            Text("URL & Port")
               .font(.system(size:12))
               .foregroundStyle(Color("TextSecondary"))
               .frame(maxWidth: .infinity, alignment: .leading)
+            
+           
             
             TextField("URL", text: $hostURL)
               .textFieldStyle(PlainTextFieldStyle())
@@ -213,37 +256,38 @@ struct macosHostAddConnectionDetailsView: View {
                   .stroke(selectedPortField ? Color("LabelBackgroundBorder") : Color("BackgroundAlt"), lineWidth: 1)
               )
             
-            Button {
-              
-              selfSignedCertificates.toggle()
-              host.host?.selfSignedCertificate = selfSignedCertificates
-            } label: {
-              HStack {
-                Spacer()
-                Text("Allow self signed certificates")
-                Image(systemName: selfSignedCertificates ? "checkmark.circle.fill" : "circle")
-                  .padding(10)
-                  .background(Color("Button"))
-                  .clipShape(.rect(cornerRadius: 5))
-              }
-            }.buttonStyle(PlainButtonStyle())
-              .frame(maxWidth: .infinity)
-              .onAppear {
-                if let item = item,
-                   let selfSigned = item.host?.selfSignedCertificate {
-                  DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-                    withAnimation {
-                      self.selfSignedCertificates = selfSigned
-                      if host.host == nil {
-                        host.host = HostURL()
-                      }
-                      self.host.host?.selfSignedCertificate = selfSigned
-                    }
-                  }
-                } else if let selfSignedCertificates =  host.host?.selfSignedCertificate {
-                  self.selfSignedCertificates = selfSignedCertificates
+            if showSelfSignedView {
+              Button {
+                selfSignedCertificates.toggle()
+                host.host?.selfSignedCertificate = selfSignedCertificates
+              } label: {
+                HStack {
+                  Spacer()
+                  Text("Allow self signed certificates")
+                  Image(systemName: selfSignedCertificates ? "checkmark.circle.fill" : "circle")
+                    .padding(10)
+                    .background(Color("Button"))
+                    .clipShape(.rect(cornerRadius: 5))
                 }
-              }
+              }.buttonStyle(PlainButtonStyle())
+                .frame(maxWidth: .infinity)
+                .onAppear {
+                  if let item = item,
+                     let selfSigned = item.host?.selfSignedCertificate {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                      withAnimation {
+                        self.selfSignedCertificates = selfSigned
+                        if host.host == nil {
+                          host.host = HostURL()
+                        }
+                        self.host.host?.selfSignedCertificate = selfSigned
+                      }
+                    }
+                  } else if let selfSignedCertificates =  host.host?.selfSignedCertificate {
+                    self.selfSignedCertificates = selfSignedCertificates
+                  }
+                }
+            }
           }
           .onChange(of: focusedField, perform: { newValue in
             // selected the textfield view, needs a negative check on selected
@@ -264,5 +308,6 @@ struct macosHostAddConnectionDetailsView: View {
           })
         }
       }
+
     }
 }

--- a/Source/Platforms/macOS/Hosts/macosHostsAdd/macosHostAddConnectionDetailsView.swift
+++ b/Source/Platforms/macOS/Hosts/macosHostsAdd/macosHostAddConnectionDetailsView.swift
@@ -139,26 +139,26 @@ struct macosHostAddConnectionDetailsView: View {
             
             // updateScheme updates the scheme for the host and manages related UI state.
             let updateScheme: (HostScheme) -> Void = { newValue in
-                
-                // Ensure host is initialized
-                if host.host == nil {
-                  host.host = HostURL()
-                }
-                
-                // Sets the scheme on host
-                host.host?.scheme = newValue
-                // Updates the local schemeUpdate state for state management
+              
+              // Ensure host is initialized
+              if host.host == nil {
+                host.host = HostURL()
+              }
+              
+              // Sets the scheme on host
+              host.host?.scheme = newValue
+              // Updates the local schemeUpdate state for state management, checks to avoid circular dependency
               if self.schemeUpdate != newValue {
                 self.schemeUpdate = newValue
               }
-
-                // Shows or hides the self-signed certificate option based on scheme
-                if newValue == HostScheme.HTTPS {
-                  showSelfSignedView = true
-                } else {
-                  showSelfSignedView = false
-                  host.host?.selfSignedCertificate = false
-                }
+              
+              // Shows or hides the self-signed certificate option based on scheme
+              if newValue == HostScheme.HTTPS {
+                showSelfSignedView = true
+              } else {
+                showSelfSignedView = false
+                host.host?.selfSignedCertificate = false
+              }
             }
             
             macosHostsSchemePickerView(localScheme: $schemeUpdate)

--- a/Source/Platforms/macOS/Hosts/macosHostsAdd/macosHostsSchemePickerView.swift
+++ b/Source/Platforms/macOS/Hosts/macosHostsAdd/macosHostsSchemePickerView.swift
@@ -9,7 +9,7 @@
 import SwiftUI
 
 struct macosHostsSchemePickerView: View {
-
+  
   @Binding var localScheme: HostScheme
   var body: some View {
     VStack (spacing:5) {
@@ -24,6 +24,7 @@ struct macosHostsSchemePickerView: View {
         } label: {
           Text("https")
             .padding(10)
+            .frame(width: 80)
             .background(localScheme == .HTTPS ? Color("ButtonHighlighted") : Color("Button"))
             .clipShape(.rect(cornerRadius: 5))
             .contentShape(Rectangle())
@@ -36,6 +37,7 @@ struct macosHostsSchemePickerView: View {
         } label: {
           Text("http")
             .padding(10)
+            .frame(width: 80)
             .background(localScheme == .HTTP ? Color("ButtonHighlighted") : Color("Button"))
             .clipShape(.rect(cornerRadius: 5))
             .contentShape(Rectangle())
@@ -46,4 +48,3 @@ struct macosHostsSchemePickerView: View {
     }
   }
 }
-

--- a/Source/Platforms/macOS/Hosts/macosHostsAdd/macosHostsSchemePickerView.swift
+++ b/Source/Platforms/macOS/Hosts/macosHostsAdd/macosHostsSchemePickerView.swift
@@ -1,0 +1,49 @@
+// SearchOps Source Code
+// UI macOS Presentation Logic for SearchOps Application
+// https://apps.apple.com/app/search-ops/id6453696339
+//
+// (c) 2025 Ryan McCaffery
+// This code is licensed under MIT license (see LICENSE.txt for details)
+// ---------------------------------------
+
+import SwiftUI
+
+struct macosHostsSchemePickerView: View {
+
+  @Binding var localScheme: HostScheme
+  var body: some View {
+    VStack (spacing:5) {
+      Text("URI Scheme")
+        .font(.system(size:12))
+        .foregroundStyle(Color("TextSecondary"))
+        .frame(maxWidth: .infinity, alignment: .leading)
+      
+      HStack {
+        Button {
+          localScheme = HostScheme.HTTPS
+        } label: {
+          Text("https")
+            .padding(10)
+            .background(localScheme == .HTTPS ? Color("ButtonHighlighted") : Color("Button"))
+            .clipShape(.rect(cornerRadius: 5))
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(PlainButtonStyle())
+        
+        
+        Button {
+          localScheme = HostScheme.HTTP
+        } label: {
+          Text("http")
+            .padding(10)
+            .background(localScheme == .HTTP ? Color("ButtonHighlighted") : Color("Button"))
+            .clipShape(.rect(cornerRadius: 5))
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(PlainButtonStyle())
+        Spacer()
+      }
+    }
+  }
+}
+

--- a/Source/Platforms/macOS/Hosts/macosHostsAdd/macosHostsTestConnectionView.swift
+++ b/Source/Platforms/macOS/Hosts/macosHostsAdd/macosHostsTestConnectionView.swift
@@ -18,8 +18,6 @@ struct macosHostsTestConnectionView : View {
   @MainActor
   func queryElastic() async {
     
-//    guard let item = host else { return }
-    
     response = await Search.testHost(serverDetails: item)
     loading = false
     


### PR DESCRIPTION
This pull request introduces a new UI component for selecting host URI schemes and updates the default port configuration, along with minor improvements to the host connection details workflow and project metadata. 

The most significant change is the addition of the `macosHostsSchemePickerView`, which enables users to choose between HTTP and HTTPS schemes when adding a new host, and dynamically manages related UI elements such as the self-signed certificate option.

**UI Enhancements for Host Scheme Selection:**

* Added new file `macosHostsSchemePickerView.swift` to provide a UI for selecting between HTTP and HTTPS schemes when configuring a host. This view uses a button-based selection and updates state via a binding.
* Integrated `macosHostsSchemePickerView` into `macosHostAddConnectionDetailsView.swift`, including logic to update the host's scheme and show/hide the self-signed certificate option based on the selected scheme. [[1]](diffhunk://#diff-dfc808411a9c1f58dd3ca1c6b20c15166d6b42919f259c00364da43e6dcda153L137-R182) [[2]](diffhunk://#diff-dfc808411a9c1f58dd3ca1c6b20c15166d6b42919f259c00364da43e6dcda153R256-L217)

**Project Structure and Metadata:**

* Registered the new `macosHostsSchemePickerView.swift` file in the Xcode project, added it to relevant groups and build phases, and incremented the project version and marketing version. [[1]](diffhunk://#diff-90faf978b49a7e2af1a72ab0c487bcb5dc27975b03a506f6600550615206d967R227) [[2]](diffhunk://#diff-90faf978b49a7e2af1a72ab0c487bcb5dc27975b03a506f6600550615206d967R649) [[3]](diffhunk://#diff-90faf978b49a7e2af1a72ab0c487bcb5dc27975b03a506f6600550615206d967R2087) [[4]](diffhunk://#diff-90faf978b49a7e2af1a72ab0c487bcb5dc27975b03a506f6600550615206d967R2495) [[5]](diffhunk://#diff-90faf978b49a7e2af1a72ab0c487bcb5dc27975b03a506f6600550615206d967L2836-R2840) [[6]](diffhunk://#diff-90faf978b49a7e2af1a72ab0c487bcb5dc27975b03a506f6600550615206d967L2861-R2865) [[7]](diffhunk://#diff-90faf978b49a7e2af1a72ab0c487bcb5dc27975b03a506f6600550615206d967L2885-R2889) [[8]](diffhunk://#diff-90faf978b49a7e2af1a72ab0c487bcb5dc27975b03a506f6600550615206d967L2910-R2914)